### PR TITLE
Update download links to point to official repository

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,15 +17,15 @@
     <!-- HEADER -->
     <div id="header_wrap" class="outer">
         <header class="inner">
-          <a id="forkme_banner" href="{{ site.github.repository_url }}">View on GitHub</a>
+          <a id="forkme_banner" href="https://github.com/workman-layout/Workman">View on GitHub</a>
 
           <h1 id="project_title">{{ site.title | default: site.github.repository_name }}</h1>
           <h2 id="project_tagline">{{ site.description | default: site.github.project_tagline }}</h2>
 
           {% if site.show_downloads %}
             <section id="downloads">
-              <a class="zip_download_link" href="https://github.com/kdeloach/Workman/zipball/master">Download this project as a .zip file</a>
-              <a class="tar_download_link" href="https://github.com/kdeloach/Workman/tarball/master">Download this project as a tar.gz file</a>
+              <a class="zip_download_link" href="https://github.com/workman-layout/Workman/zipball/master">Download this project as a .zip file</a>
+              <a class="tar_download_link" href="https://github.com/workman-layout/Workman/tarball/master">Download this project as a tar.gz file</a>
             </section>
           {% endif %}
         </header>

--- a/index.md
+++ b/index.md
@@ -471,7 +471,7 @@ Sure go ahead! Feel free to use it if you would like. Below is a
 link to the implementation/installation files courtesy of
 David Norman (deekayen).
 
-[Download the Workman Layout](https://github.com/kdeloach/workman/zipball/master)
+[Download the Workman Layout](https://github.com/workman-layout/Workman/zipball/master)
 
 **IMPORTANT:** The Workman Keyboard Layout is only a partial
 solution. Even the best keyboard layout could not completely


### PR DESCRIPTION
While https://github.com/workman-layout/Workman/pull/39 is still waiting to be reviewed, it could be good to update the current version of the site to point to the official workman repository. This updates the download links to point to the main repository.

Fixes https://github.com/workman-layout/Workman/issues/41.